### PR TITLE
Set RecursionDesired header to fix SERVFAIL

### DIFF
--- a/dnsmasq.go
+++ b/dnsmasq.go
@@ -109,7 +109,8 @@ func main() {
 		eg.Go(func() error {
 			msg := &dns.Msg{
 				MsgHdr: dns.MsgHdr{
-					Id: dns.Id(),
+					Id:               dns.Id(),
+					RecursionDesired: true,
 				},
 				Question: []dns.Question{
 					dns.Question{"cachesize.bind.", dns.TypeTXT, dns.ClassCHAOS},


### PR DESCRIPTION
I was having issues with collecting DNS metrics(all 0s) and I found out that `dnsmasq` was responding with `SERVFAIL` errors, setting `RecursionDesired: true` fixed the issue.
Should a bug be submitted for https://github.com/miekg/dns since this is a silent failure?

**Note:** I submitted a CLA to google as requested on contributing guideline.