### PR TITLE
Fix missing leases

### DIFF
--- a/dnsmasq.go
+++ b/dnsmasq.go
@@ -161,7 +161,11 @@ func (s *server) metrics(w http.ResponseWriter, r *http.Request) {
 	})
 
 	eg.Go(func() error {
-		if _, err := os.Stat(s.leasesPath); err == nil {
+		if _, err := os.Stat(s.leasesPath); err != nil {
+			log.Warnln("did not find leases file, skipped")
+			return nil
+
+		} else {
 			f, err := os.Open(s.leasesPath)
 			if err != nil {
 				log.Warnln("could not open leases file:", err)
@@ -177,9 +181,6 @@ func (s *server) metrics(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 			leases.Set(lines)
-			return nil
-		} else {
-			log.Warnln("did not find leases file, skipped")
 			return nil
 		}
 	})

--- a/dnsmasq.go
+++ b/dnsmasq.go
@@ -179,7 +179,7 @@ func (s *server) metrics(w http.ResponseWriter, r *http.Request) {
 			leases.Set(lines)
 			return nil
 		} else {
-			log.Warnln("did not find open leases file, skipped")
+			log.Warnln("did not find leases file, skipped")
 			return nil
 		}
 	})


### PR DESCRIPTION
This resolves an issue for folks using dnsmasq solely as a caching/forwarding DNS server who may not have a leases file by checking for status first, then reacting accordingly.