### PR TITLE
add flag for disabling dhcp metrics

### DIFF
--- a/dnsmasq_test.go
+++ b/dnsmasq_test.go
@@ -65,8 +65,9 @@ func TestDnsmasqExporter(t *testing.T) {
 		dnsClient: &dns.Client{
 			SingleInflight: true,
 		},
-		dnsmasqAddr: "localhost:" + port,
-		leasesPath:  "testdata/dnsmasq.leases",
+		dnsmasqAddr:         "localhost:" + port,
+		leasesPath:          "testdata/dnsmasq.leases",
+		disableLeaseMetrics: false,
 	}
 
 	t.Run("first", func(t *testing.T) {


### PR DESCRIPTION
If a .leases-file is not available metrics scraping will fail. Adding a flag `-disable_lease_metrics` that will disable that part of the code.
On Ubuntu 20.04 with dnsmasq 2.80 running with default settings no dnsmasq.leases was available.