### PR TITLE
Metrics collection should not break on missing leases file

### DIFF
--- a/dnsmasq.go
+++ b/dnsmasq.go
@@ -209,6 +209,11 @@ func (s *server) metrics(w http.ResponseWriter, r *http.Request) {
 	eg.Go(func() error {
 		f, err := os.Open(s.leasesPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				// ignore
+				leases.Set(0)
+				return nil
+			}
 			log.Warnln("could not open leases file:", err)
 			return err
 		}

--- a/dnsmasq_test.go
+++ b/dnsmasq_test.go
@@ -120,6 +120,24 @@ func TestDnsmasqExporter(t *testing.T) {
 			}
 		}
 	})
+
+	s.leasesPath = "testdata/dnsmasq.leases.does.not.exists"
+
+	t.Run("without leases file", func(t *testing.T) {
+		metrics := fetchMetrics(t, s)
+		want := map[string]string{
+			"dnsmasq_leases":    "0",
+			"dnsmasq_cachesize": "666",
+			"dnsmasq_hits":      "4",
+			"dnsmasq_misses":    "1",
+		}
+		for key, val := range want {
+			if got, want := metrics[key], val; got != want {
+				t.Errorf("metric %q: got %q, want %q", key, got, want)
+			}
+		}
+	})
+
 }
 
 func fetchMetrics(t *testing.T, s *server) map[string]string {


### PR DESCRIPTION
Ignore errors occurring from missing leases file.