### PR TITLE
Datasource template variable should be labelled 'Data Source'

### DIFF
--- a/dnsmasq-mixin/dnsmasq-overview.json
+++ b/dnsmasq-mixin/dnsmasq-overview.json
@@ -498,7 +498,7 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Data Source",
         "multi": false,
         "name": "datasource",
         "options": [],


### PR DESCRIPTION
Hello! We're building a linter for mixins & grafana dashboards and this was one of the things that it turned up. Sorry for the super minor nit!

Signed-off-by: Tom Wilkie <tom@grafana.com>