### PR TITLE
Update dashboard schema & fix lint issues

### DIFF
--- a/dnsmasq-mixin/dnsmasq-overview.json
+++ b/dnsmasq-mixin/dnsmasq-overview.json
@@ -3,25 +3,37 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 34,
-  "iteration": 1602437170658,
+  "id": 94,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -30,14 +42,24 @@
       },
       "id": 15,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "DNS Stats",
       "type": "row"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -73,11 +95,15 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(dnsmasq_leases{job=~\"$job\", instance=~\"$instance\"})",
           "instant": false,
           "interval": "",
@@ -85,16 +111,15 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Leases",
       "type": "stat"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -131,11 +156,15 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(dnsmasq_servers_queries{job=~\"$job\", instance=~\"$instance\"})",
           "instant": false,
           "interval": "",
@@ -143,17 +172,18 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Upstream Queries",
       "type": "stat"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
+          "max": 1,
+          "min": 0,
           "noValue": "0%",
           "thresholds": {
             "mode": "absolute",
@@ -190,11 +220,15 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(dnsmasq_servers_queries_failed{job=~\"$job\", instance=~\"$instance\"}) / sum(dnsmasq_servers_queries{job=~\"$job\", instance=~\"$instance\"})",
           "instant": false,
           "interval": "",
@@ -202,14 +236,15 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Upstream Failed Queries",
       "type": "stat"
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -218,15 +253,27 @@
       },
       "id": 13,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Build Info",
       "type": "row"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
-            "align": null
+            "displayMode": "auto",
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -253,11 +300,21 @@
       },
       "id": 4,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "dnsmasq_exporter_build_info{job=~\"$job\", instance=~\"$instance\"}",
           "format": "time_series",
           "instant": true,
@@ -266,12 +323,14 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Build Info",
       "transformations": [
         {
           "id": "labelsToFields",
+          "options": {}
+        },
+        {
+          "id": "merge",
           "options": {}
         },
         {
@@ -301,7 +360,10 @@
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -310,14 +372,24 @@
       },
       "id": 11,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Cache Stats",
       "type": "row"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -353,11 +425,15 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(dnsmasq_cachesize{job=~\"$job\", instance=~\"$instance\"})",
           "instant": false,
           "interval": "",
@@ -365,16 +441,15 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Cache Size",
       "type": "stat"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -410,11 +485,15 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(dnsmasq_hits{job=~\"$job\", instance=~\"$instance\"})",
           "instant": false,
           "interval": "",
@@ -422,16 +501,15 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Cache Hits",
       "type": "stat"
     },
     {
-      "datasource": "$datasource",
+      "datasource": {
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -467,11 +545,15 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.4",
+      "pluginVersion": "9.3.2-67a213dc85",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(dnsmasq_insertions{job=~\"$job\", instance=~\"$instance\"})",
           "instant": false,
           "interval": "",
@@ -479,22 +561,20 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Cache Insertions",
       "type": "stat"
     }
   ],
-  "schemaVersion": 25,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "prometheus",
-          "value": "prometheus"
+          "selected": false,
+          "text": "grafanacloud-emilyrager-prom",
+          "value": "grafanacloud-emilyrager-prom"
         },
         "hide": 0,
         "includeAll": false,
@@ -512,38 +592,29 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
-          "text": "dnsmasq",
-          "value": [
-            "dnsmasq"
-          ]
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "definition": "label_values(dnsmasq_exporter_build_info, job)",
         "hide": 0,
         "includeAll": true,
         "label": "job",
         "multi": true,
         "name": "job",
-        "options": [
-          {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": true,
-            "text": "dnsmasq",
-            "value": "dnsmasq"
-          }
-        ],
-        "query": "label_values(dnsmasq_exporter_build_info, job)",
-        "refresh": 0,
+        "options": [],
+        "query": {
+          "query": "label_values(dnsmasq_exporter_build_info, job)",
+          "refId": "grafanacloud-emilyrager-prom-job-Variable-Query"
+        },
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -551,38 +622,29 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
-          "text": "router.lan",
-          "value": [
-            "router.lan"
-          ]
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "definition": "label_values(dnsmasq_exporter_build_info, instance)",
         "hide": 0,
         "includeAll": true,
         "label": "instance",
         "multi": true,
         "name": "instance",
-        "options": [
-          {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
-          {
-            "selected": true,
-            "text": "router.lan",
-            "value": "router.lan"
-          }
-        ],
-        "query": "label_values(dnsmasq_exporter_build_info, instance)",
-        "refresh": 0,
+        "options": [],
+        "query": {
+          "query": "label_values(dnsmasq_exporter_build_info, instance)",
+          "refId": "grafanacloud-emilyrager-prom-instance-Variable-Query"
+        },
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -609,5 +671,6 @@
   "timezone": "",
   "title": "dnsmasq",
   "uid": "ySypWTcMk",
-  "version": 2
+  "version": 2,
+  "weekStart": ""
 }

--- a/dnsmasq-mixin/dnsmasq-overview.json
+++ b/dnsmasq-mixin/dnsmasq-overview.json
@@ -222,7 +222,7 @@
       "type": "row"
     },
     {
-      "datasource": "prometheus",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -510,7 +510,7 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {
           "selected": true,
           "text": "dnsmasq",
@@ -522,7 +522,7 @@
         "definition": "label_values(dnsmasq_exporter_build_info, job)",
         "hide": 0,
         "includeAll": true,
-        "label": null,
+        "label": "job",
         "multi": true,
         "name": "job",
         "options": [
@@ -549,7 +549,7 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
         "current": {
           "selected": true,
           "text": "router.lan",
@@ -561,7 +561,7 @@
         "definition": "label_values(dnsmasq_exporter_build_info, instance)",
         "hide": 0,
         "includeAll": true,
-        "label": null,
+        "label": "instance",
         "multi": true,
         "name": "instance",
         "options": [


### PR DESCRIPTION
This PR introduces the following two changes:
- The dnsmasq dashboard in the mixin has been updated to the latest Grafana schema
- Linting issues reported by [Mixtool](https://github.com/monitoring-mixins/mixtool) have been addressed