### PR TITLE
Feat/more verbose parse error

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -306,7 +306,7 @@ func readLeaseFile(path string) ([]lease, error) {
 		if activeLease, err := parseLease(leaseLine); err == nil {
 			activeLeases = append(activeLeases, *activeLease)
 		} else {
-			log.Print(fmt.Errorf("error parsing lease (%d, %s): %w", i, leaseLine, err))
+			log.Printf("Error parsing lease (%d, %q): %s", i, leaseLine, err)
 		}
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -301,12 +301,12 @@ func readLeaseFile(path string) ([]lease, error) {
 
 	scanner := bufio.NewScanner(f)
 	activeLeases := []lease{}
-	for scanner.Scan() {
+	for i := 1; scanner.Scan(); i++ {
 		leaseLine := scanner.Text()
 		if activeLease, err := parseLease(leaseLine); err == nil {
 			activeLeases = append(activeLeases, *activeLease)
 		} else {
-			log.Print(fmt.Errorf("error parsing lease (%s): %w", leaseLine, err))
+			log.Print(fmt.Errorf("error parsing lease (%d, %s): %w", i, leaseLine, err))
 		}
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -302,12 +302,12 @@ func readLeaseFile(path string) ([]lease, error) {
 	scanner := bufio.NewScanner(f)
 	activeLeases := []lease{}
 	for scanner.Scan() {
-		activeLease, err := parseLease(scanner.Text())
-		if err != nil {
-			return nil, err
+		leaseLine := scanner.Text()
+		if activeLease, err := parseLease(leaseLine); err == nil {
+			activeLeases = append(activeLeases, *activeLease)
+		} else {
+			log.Print(fmt.Errorf("error parsing lease (%s): %w", leaseLine, err))
 		}
-
-		activeLeases = append(activeLeases, *activeLease)
 	}
 
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
### Description
In our environment we encountered the same error described in #29: our dnsmasq-exporter reports a lease parsing error, and meanwhile we don't have metrics and don't know why this is happening.
I thought that a better handling in this case could be to continue parsing the file while ignore the faulty lease, and reporting the line with the error.
Let me know what you think about this 😄 